### PR TITLE
call keyboard destroy function on $scope destroy

### DIFF
--- a/src/ng-virtual-keyboard.js
+++ b/src/ng-virtual-keyboard.js
@@ -123,6 +123,9 @@ angular.module('ng-virtual-keyboard', [])
 						ngModelCtrl.$setViewValue(elements[0].value);
 					});
 				});
+				scope.$on("$destroy", function() {
+					$(elements[0]).keyboard().getkeyboard().destroy();
+				});
 			}
 		};
 	}


### PR DESCRIPTION
call keyboard destroy function on $scope destroy to clean and remove all listeners on the page that can cause memory leak and grow up without any control during page usage.